### PR TITLE
fix(search): adds utils for hash test + fix search issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,8 @@ services:
 env:
   - MOZ_HEADLESS=1
 addons:
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - docker-ce
-      - google-chrome-stable
   firefox: latest
+  chrome: stable
 
 branches:
   only:
@@ -33,7 +28,6 @@ before_install:
   # Use latest supported NPM in order to speedup build and support `npm ci`
   - npm i -g npm@6
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 
 install:
   - npm ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: trusty
+dist: xenial
 language: node_js
 
 node_js:

--- a/public/src/js/app.js
+++ b/public/src/js/app.js
@@ -15,6 +15,7 @@ angular.module('insight',[
   'angularMoment',
   'insight.system',
   'insight.socket',
+  'insight.hash',
   'insight.blocks',
   'insight.transactions',
   'insight.address',
@@ -27,6 +28,7 @@ angular.module('insight',[
 
 angular.module('insight.system', []);
 angular.module('insight.socket', []);
+angular.module('insight.hash', []);
 angular.module('insight.blocks', []);
 angular.module('insight.transactions', []);
 angular.module('insight.address', []);

--- a/public/src/js/controllers/header.js
+++ b/public/src/js/controllers/header.js
@@ -1,8 +1,15 @@
 'use strict';
 
 angular.module('insight.system').controller('HeaderController',
-  function($scope, $rootScope, $uibModal, getSocket, Global, Block) {
+  function($scope, $rootScope, $uibModal, getSocket, Global, Block, Status) {
     $scope.global = Global;
+
+    // This allow us to do crafted logic by the network, such can be seen in BlockHash.test().
+    $rootScope.network = 'testnet';
+    Status.get({},
+      function(status) {
+        $rootScope.network = status.info && status.info.network || 'testnet';
+    });
 
     $rootScope.currency = {
       factor: 1,

--- a/public/src/js/controllers/search.js
+++ b/public/src/js/controllers/search.js
@@ -23,8 +23,6 @@ angular.module('insight.search')
 
       $scope.search = function () {
         var q = $scope.q;
-        console.log('$scope.search - scope.q', $scope.q);
-        console.log('$scope.search - scope', $scope);
         $scope.badQuery = false;
         $scope.loading = true;
 
@@ -38,7 +36,6 @@ angular.module('insight.search')
           _badQuery();
         };
 
-
         var fetchAndRedirectTransactionSearch = function(){
           return Transaction.get({
             txId: q
@@ -48,34 +45,42 @@ angular.module('insight.search')
           }, badQueryLoadHandler);
         };
 
-        if (isBlockHeight) {
-          BlockByHeight.get({
+        var fetchAndRedirectBlockHeightSearch = function () {
+          return BlockByHeight.get({
             blockHeight: q
           }, function (hash) {
             _resetSearch();
             $location.path('/block/' + hash.blockHash);
           }, badQueryLoadHandler);
-        } else if (isAddress) {
-          Address.get({
+        }
+        var fetchAndRedirectAddressSearch = function () {
+          return Address.get({
             addrStr: q
           }, function () {
             _resetSearch();
             $location.path('address/' + q);
           }, badQueryLoadHandler);
-        } else if (isBlockHash) {
+        }
+        var fetchAndRedirectBlockSearch = function () {
           // Block hashes are identified by expecting 10 trailing zeroes as prefix (see difficulty)
           // If we are in the 1/Inf case of a txhash starting with ten zeroes, we will fallback on tx
-          Block.get({
+          return Block.get({
             blockHash: q
           }, function () {
             _resetSearch();
             $location.path('/block/' + q);
           }, fetchAndRedirectTransactionSearch);
+        };
+
+        if (isBlockHeight) {
+          fetchAndRedirectBlockHeightSearch();
+        } else if (isAddress) {
+          fetchAndRedirectAddressSearch();
+        } else if (isBlockHash) {
+          fetchAndRedirectBlockSearch();
         } else if (isTransactionHash) {
           fetchAndRedirectTransactionSearch();
         } else {
-          console.log('Query not identified');
-          console.log(q);
           badQueryLoadHandler();
         }
       };

--- a/public/src/js/controllers/search.js
+++ b/public/src/js/controllers/search.js
@@ -1,64 +1,76 @@
 'use strict';
+// var isValidBlockHash = require('../utils/isValidBlockHash');
+// var isValidAddress = require('../utils/isValidAddress');
+// var isValidTransactionHash = require('../utils/isValidTransactionHash');
+angular.module('insight.search')
+  .controller('SearchController',
+    function ($scope, $routeParams, $location, $timeout, Global, Block, Transaction, Address, BlockHashValidator, TransactionHashValidator, AddressValidator, BlockByHeight) {
+      $scope.global = Global;
+      $scope.loading = false;
 
-angular.module('insight.search').controller('SearchController',
-  function($scope, $routeParams, $location, $timeout, Global, Block, Transaction, Address, BlockByHeight) {
-  $scope.global = Global;
-  $scope.loading = false;
+      var _badQuery = function () {
+        $scope.badQuery = true;
 
-  var _badQuery = function() {
-    $scope.badQuery = true;
+        $timeout(function () {
+          $scope.badQuery = false;
+        }, 2000);
+      };
 
-    $timeout(function() {
-      $scope.badQuery = false;
-    }, 2000);
-  };
+      var _resetSearch = function () {
+        $scope.q = '';
+        $scope.loading = false;
+      };
 
-  var _resetSearch = function() {
-    $scope.q = '';
-    $scope.loading = false;
-  };
+      $scope.search = function () {
+        var q = $scope.q;
+        console.log('$scope.search - scope.q', $scope.q);
+        console.log('$scope.search - scope', $scope);
+        $scope.badQuery = false;
+        $scope.loading = true;
 
-  $scope.search = function() {
-    var q = $scope.q;
-    $scope.badQuery = false;
-    $scope.loading = true;
+        var isBlockHeight = isFinite(q);
+        var isBlockHash = BlockHashValidator.test(q);
+        var isTransactionHash = TransactionHashValidator.test(q);
+        var isAddress = AddressValidator.test(q);
 
-    Block.get({
-      blockHash: q
-    }, function() {
-      _resetSearch();
-      $location.path('block/' + q);
-    }, function() { //block not found, search on TX
-      Transaction.get({
-        txId: q
-      }, function() {
-        _resetSearch();
-        $location.path('tx/' + q);
-      }, function() { //tx not found, search on Address
-        Address.get({
-          addrStr: q
-        }, function() {
-          _resetSearch();
-          $location.path('address/' + q);
-        }, function() { // block by height not found
-          if (isFinite(q)) { // ensure that q is a finite number. A logical height value.
-            BlockByHeight.get({
-              blockHeight: q
-            }, function(hash) {
-              _resetSearch();
-              $location.path('/block/' + hash.blockHash);
-            }, function() { //not found, fail :(
-              $scope.loading = false;
-              _badQuery();
-            });
-          }
-          else {
-            $scope.loading = false;
-            _badQuery();
-          }
-        });
-      });
+        var badQueryLoadHandler = function () {
+          $scope.loading = false;
+          _badQuery();
+        };
+        if (isBlockHeight) {
+          BlockByHeight.get({
+            blockHeight: q
+          }, function (hash) {
+            _resetSearch();
+            $location.path('/block/' + hash.blockHash);
+          }, badQueryLoadHandler);
+        } else if (isAddress) {
+          Address.get({
+            addrStr: q
+          }, function () {
+            _resetSearch();
+            $location.path('address/' + q);
+          }, badQueryLoadHandler);
+
+        } else if (isBlockHash) {
+          Block.get({
+            blockHash: q
+          }, function () {
+            _resetSearch();
+            $location.path('/block/' + q);
+          }, badQueryLoadHandler);
+        } else if (isTransactionHash) {
+          Transaction.get({
+            txId: q
+          }, function () {
+            _resetSearch();
+            $location.path('/tx/' + q);
+          }, badQueryLoadHandler);
+        } else {
+          console.log('Query not identified');
+          console.log(q);
+          badQueryLoadHandler();
+        }
+      };
+
     });
-  };
-
-});

--- a/public/src/js/controllers/search.js
+++ b/public/src/js/controllers/search.js
@@ -1,12 +1,12 @@
 'use strict';
-// var isValidBlockHash = require('../utils/isValidBlockHash');
-// var isValidAddress = require('../utils/isValidAddress');
-// var isValidTransactionHash = require('../utils/isValidTransactionHash');
+
 angular.module('insight.search')
   .controller('SearchController',
-    function ($scope, $routeParams, $location, $timeout, Global, Block, Transaction, Address, BlockHashValidator, TransactionHashValidator, AddressValidator, BlockByHeight) {
+    function ($scope, $rootScope, $routeParams, $location, $timeout, Global, Block, Transaction, Address, BlockHashValidator, TransactionHashValidator, AddressValidator, BlockByHeight) {
       $scope.global = Global;
       $scope.loading = false;
+
+      var currentNetwork = $rootScope.network;
 
       var _badQuery = function () {
         $scope.badQuery = true;
@@ -25,9 +25,8 @@ angular.module('insight.search')
         var q = $scope.q;
         $scope.badQuery = false;
         $scope.loading = true;
-
         var isBlockHeight = isFinite(q);
-        var isBlockHash = BlockHashValidator.test(q);
+        var isBlockHash = BlockHashValidator.test(q, currentNetwork);
         var isTransactionHash = TransactionHashValidator.test(q);
         var isAddress = AddressValidator.test(q);
 
@@ -52,7 +51,7 @@ angular.module('insight.search')
             _resetSearch();
             $location.path('/block/' + hash.blockHash);
           }, badQueryLoadHandler);
-        }
+        };
         var fetchAndRedirectAddressSearch = function () {
           return Address.get({
             addrStr: q
@@ -60,7 +59,7 @@ angular.module('insight.search')
             _resetSearch();
             $location.path('address/' + q);
           }, badQueryLoadHandler);
-        }
+        };
         var fetchAndRedirectBlockSearch = function () {
           // Block hashes are identified by expecting 10 trailing zeroes as prefix (see difficulty)
           // If we are in the 1/Inf case of a txhash starting with ten zeroes, we will fallback on tx

--- a/public/src/js/controllers/search.js
+++ b/public/src/js/controllers/search.js
@@ -37,6 +37,17 @@ angular.module('insight.search')
           $scope.loading = false;
           _badQuery();
         };
+
+
+        var fetchAndRedirectTransactionSearch = function(){
+          return Transaction.get({
+            txId: q
+          }, function () {
+            _resetSearch();
+            $location.path('/tx/' + q);
+          }, badQueryLoadHandler);
+        };
+
         if (isBlockHeight) {
           BlockByHeight.get({
             blockHeight: q
@@ -51,21 +62,17 @@ angular.module('insight.search')
             _resetSearch();
             $location.path('address/' + q);
           }, badQueryLoadHandler);
-
         } else if (isBlockHash) {
+          // Block hashes are identified by expecting 10 trailing zeroes as prefix (see difficulty)
+          // If we are in the 1/Inf case of a txhash starting with ten zeroes, we will fallback on tx
           Block.get({
             blockHash: q
           }, function () {
             _resetSearch();
             $location.path('/block/' + q);
-          }, badQueryLoadHandler);
+          }, fetchAndRedirectTransactionSearch);
         } else if (isTransactionHash) {
-          Transaction.get({
-            txId: q
-          }, function () {
-            _resetSearch();
-            $location.path('/tx/' + q);
-          }, badQueryLoadHandler);
+          fetchAndRedirectTransactionSearch();
         } else {
           console.log('Query not identified');
           console.log(q);

--- a/public/src/js/controllers/search.js
+++ b/public/src/js/controllers/search.js
@@ -65,7 +65,10 @@ angular.module('insight.search')
           // If we are in the 1/Inf case of a txhash starting with ten zeroes, we will fallback on tx
           return Block.get({
             blockHash: q
-          }, function () {
+          }, function (res) {
+            if(res.status === 404){
+              return fetchAndRedirectTransactionSearch();
+            }
             _resetSearch();
             $location.path('/block/' + q);
           }, fetchAndRedirectTransactionSearch);

--- a/public/src/js/controllers/status.js
+++ b/public/src/js/controllers/status.js
@@ -26,14 +26,15 @@ angular.module('insight.status').controller('StatusController',
       $scope.sync = sync;
     };
 
+    var socket = getSocket($scope);
+
     var _startSocket = function () {
       socket.emit('subscribe', 'sync');
       socket.on('status', function(sync) {
         _onSyncUpdate(sync);
       });
     };
-    
-    var socket = getSocket($scope);
+
     socket.on('connect', function() {
       _startSocket();
     });

--- a/public/src/js/controllers/transactions.js
+++ b/public/src/js/controllers/transactions.js
@@ -113,12 +113,13 @@ function($scope, $rootScope, $routeParams, $location, Global, Transaction, Trans
     Transaction.get({
       txId: txid
     }, function(tx) {
-      $rootScope.titleDetail = tx.txid.substring(0,7) + '...';
+        $rootScope.titleDetail = tx.txid.substring(0,7) + '...';
       $rootScope.flashMessage = null;
-      $scope.tx = tx;
-      _processTX(tx);
-      $scope.txs.unshift(tx);
+        $scope.tx = tx;
+        _processTX(tx);
+        $scope.txs.unshift(tx);
     }, function(e) {
+      // FIXME : Do we even enter here ? status 4** do not throw exceptions
       if (e.status === 400) {
         $rootScope.flashMessage = 'Invalid Transaction ID: ' + $routeParams.txId;
       }
@@ -164,7 +165,7 @@ function($scope, $rootScope, $routeParams, $location, Global, Transaction, Trans
     $scope.v_index = parseInt($routeParams.v_index);
     $scope.itemsExpanded = true;
   }
-  
+
   //Init without txs
   $scope.txs = [];
 

--- a/public/src/js/controllers/transactions.js
+++ b/public/src/js/controllers/transactions.js
@@ -113,8 +113,10 @@ function($scope, $rootScope, $routeParams, $location, Global, Transaction, Trans
     Transaction.get({
       txId: txid
     }, function(tx) {
-        $rootScope.titleDetail = tx.txid.substring(0,7) + '...';
-      $rootScope.flashMessage = null;
+        if(tx.txid){
+          $rootScope.titleDetail = tx.txid.substring(0,7) + '...';
+        }
+        $rootScope.flashMessage = null;
         $scope.tx = tx;
         _processTX(tx);
         $scope.txs.unshift(tx);

--- a/public/src/js/services/address.js
+++ b/public/src/js/services/address.js
@@ -1,24 +1,32 @@
 'use strict';
 
-angular.module('insight.address').factory('Address',
-  function($resource) {
-  return $resource(window.apiPrefix + '/addr/:addrStr/?noTxList=1', {
-    addrStr: '@addStr'
-  }, {
-    get: {
-      method: 'GET',
-      interceptor: {
-        response: function (res) {
-          return res.data;
-        },
-        responseError: function (res) {
-          if (res.status === 404) {
-            return res;
+angular.module('insight.address')
+  .factory('Address',
+    function ($resource) {
+      return $resource(window.apiPrefix + '/addr/:addrStr/?noTxList=1', {
+        addrStr: '@addStr'
+      }, {
+        get: {
+          method: 'GET',
+          interceptor: {
+            response: function (res) {
+              return res.data;
+            },
+            responseError: function (res) {
+              if (res.status === 404) {
+                return res;
+              }
+            }
           }
         }
-      }
-    }
-  });
-});
+      });
+    })
+  .factory('AddressValidator',
+    function () {
+      return {
+        test: function (addressStr) {
 
- 
+          return /^[XxYy][1-9A-Za-z][^OIl]{20,40}/.test(addressStr);
+        }
+      };
+    });

--- a/public/src/js/services/blocks.js
+++ b/public/src/js/services/blocks.js
@@ -29,8 +29,10 @@ angular.module('insight.blocks')
     function (HashValidator) {
       return {
         test: function (blockHashStr) {
-          return HashValidator.test64(blockHashStr) && blockHashStr.startsWith('0000') ||
-            (HashValidator.test66(blockHashStr) && blockHashStr.startsWith('0x0000'));
+          // Cir. 2014, difficulty implies at least 10 trailing zeroes. See https://github.com/dashevo/insight-ui/pull/52
+          var expectedBlockHashTrailingZeroes = '0000000000';
+          return HashValidator.test64(blockHashStr) && blockHashStr.startsWith(expectedBlockHashTrailingZeroes) ||
+            (HashValidator.test66(blockHashStr) && blockHashStr.startsWith('0x'+expectedBlockHashTrailingZeroes));
         }
       };
     })

--- a/public/src/js/services/blocks.js
+++ b/public/src/js/services/blocks.js
@@ -2,30 +2,39 @@
 
 angular.module('insight.blocks')
   .factory('Block',
-    function($resource) {
-    return $resource(window.apiPrefix + '/block/:blockHash', {
-      blockHash: '@blockHash'
-    }, {
-      get: {
-        method: 'GET',
-        interceptor: {
-          response: function (res) {
-            return res.data;
-          },
-          responseError: function (res) {
-            if (res.status === 404) {
-              return res;
+    function ($resource) {
+      return $resource(window.apiPrefix + '/block/:blockHash', {
+        blockHash: '@blockHash'
+      }, {
+        get: {
+          method: 'GET',
+          interceptor: {
+            response: function (res) {
+              return res.data;
+            },
+            responseError: function (res) {
+              if (res.status === 404) {
+                return res;
+              }
             }
           }
         }
-      }
-    });
-  })
+      });
+    })
   .factory('Blocks',
-    function($resource) {
+    function ($resource) {
       return $resource(window.apiPrefix + '/blocks');
-  })
+    })
+  .factory('BlockHashValidator',
+    function (HashValidator) {
+      return {
+        test: function (blockHashStr) {
+          return HashValidator.test64(blockHashStr) && blockHashStr.startsWith('0000') ||
+            (HashValidator.test66(blockHashStr) && blockHashStr.startsWith('0x0000'));
+        }
+      };
+    })
   .factory('BlockByHeight',
-    function($resource) {
+    function ($resource) {
       return $resource(window.apiPrefix + '/block-index/:blockHeight');
-  });
+    });

--- a/public/src/js/services/blocks.js
+++ b/public/src/js/services/blocks.js
@@ -28,9 +28,10 @@ angular.module('insight.blocks')
   .factory('BlockHashValidator',
     function (HashValidator) {
       return {
-        test: function (blockHashStr) {
+        test: function (blockHashStr, network) {
           // Cir. 2014, difficulty implies at least 10 trailing zeroes. See https://github.com/dashevo/insight-ui/pull/52
-          var expectedBlockHashTrailingZeroes = '0000000000';
+          // On testnet, we still keep it at 4 (a single micro aws achieves it)
+          var expectedBlockHashTrailingZeroes = (network==='testnet' || network === undefined) ? '0000' : '0000000000';
           return HashValidator.test64(blockHashStr) && blockHashStr.startsWith(expectedBlockHashTrailingZeroes) ||
             (HashValidator.test66(blockHashStr) && blockHashStr.startsWith('0x'+expectedBlockHashTrailingZeroes));
         }

--- a/public/src/js/services/hash.js
+++ b/public/src/js/services/hash.js
@@ -1,0 +1,14 @@
+'use strict';
+
+angular.module('insight.hash')
+  .factory('HashValidator',
+    function () {
+      return {
+        test64: function (hashStr) {
+          return typeof hashStr === 'string' && /^(0x)?[0-9a-f]{64}$/i.test(hashStr);
+        },
+        test66: function (hashStr) {
+          return typeof hashStr === 'string' && /^(0x)?[0-9a-f]{66}$/i.test(hashStr);
+        }
+      };
+    });

--- a/public/src/js/services/transactions.js
+++ b/public/src/js/services/transactions.js
@@ -2,38 +2,47 @@
 
 angular.module('insight.transactions')
   .factory('Transaction',
-    function($resource) {
-    return $resource(window.apiPrefix + '/tx/:txId', {
-      txId: '@txId'
-    }, {
-      get: {
-        method: 'GET',
-        interceptor: {
-          response: function (res) {
-            return res.data;
-          },
-          responseError: function (res) {
-            if (res.status === 404) {
-              return res;
+    function ($resource) {
+      return $resource(window.apiPrefix + '/tx/:txId', {
+        txId: '@txId'
+      }, {
+        get: {
+          method: 'GET',
+          interceptor: {
+            response: function (res) {
+              return res.data;
+            },
+            responseError: function (res) {
+              if (res.status === 404) {
+                return res;
+              }
             }
           }
         }
-      }
-    });
-  })
+      });
+    })
   .factory('TransactionsByBlock',
-    function($resource) {
-    return $resource(window.apiPrefix + '/txs', {
-      block: '@block'
-    });
-  })
+    function ($resource) {
+      return $resource(window.apiPrefix + '/txs', {
+        block: '@block'
+      });
+    })
   .factory('TransactionsByAddress',
-    function($resource) {
-    return $resource(window.apiPrefix + '/txs', {
-      address: '@address'
-    });
-  })
+    function ($resource) {
+      return $resource(window.apiPrefix + '/txs', {
+        address: '@address'
+      });
+    })
+
   .factory('Transactions',
-    function($resource) {
+    function ($resource) {
       return $resource(window.apiPrefix + '/txs');
-  });
+    })
+  .factory('TransactionHashValidator',
+    function (HashValidator, BlockHashValidator) {
+      return {
+        test: function (txHashStr) {
+          return HashValidator.test64(txHashStr) && !BlockHashValidator.test(txHashStr);
+        }
+      };
+    });


### PR DESCRIPTION
### Issue being fixed or implemented  
Search being broken on address and transaction hash considered as block hash. 

### What was done  
- Add HashValidators services (we can't required in Angular 1...), and validate first, then asks resources while we redirect. 

### Notes  