### PR TITLE
chore: update node versions in build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: xenial
 language: node_js
 
 node_js:
-  - '8'
   - '10'
+  - '12'
 
 services:
   - docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:12-alpine
 
 RUN apk add --update --no-cache git \
                                 libzmq \
@@ -25,7 +25,7 @@ ARG MAJOR_VERSION
 RUN bin/dashcore-node install @dashevo/insight-api@${MAJOR_VERSION}
 RUN bin/dashcore-node install @dashevo/insight-ui@${VERSION}
 
-FROM node:10-alpine
+FROM node:12-alpine
 
 LABEL maintainer="Dash Developers <dev@dash.org>"
 LABEL description="Dockerised Insight-Dash"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:10-alpine
 
 RUN apk add --update --no-cache git \
                                 libzmq \
@@ -25,7 +25,7 @@ ARG MAJOR_VERSION
 RUN bin/dashcore-node install @dashevo/insight-api@${MAJOR_VERSION}
 RUN bin/dashcore-node install @dashevo/insight-ui@${VERSION}
 
-FROM node:8-alpine
+FROM node:10-alpine
 
 LABEL maintainer="Dash Developers <dev@dash.org>"
 LABEL description="Dockerised Insight-Dash"

--- a/scripts/travis-deploy.sh
+++ b/scripts/travis-deploy.sh
@@ -4,7 +4,7 @@ set -xe
 
 # Update this whenever the latest Node.js LTS version changes (~ every year).
 # Do not forget to add this version to .travis.yml config also.
-LATEST_LTS_VERSION="10"
+LATEST_LTS_VERSION="12"
 
 # We want this command to succeed whether or not the Node.js version is the
 # latest (so that the build does not show as failed), but _only_ the latest


### PR DESCRIPTION
This PR removes node v.8.0 from travis build and adds node v.12
In Dockerfile, Alpine and LTS are migrated from node v.10 to v.12 