### PR TITLE
fix: .error/.success removed in Angular

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ before_install:
   # Use latest supported NPM in order to speedup build and support `npm ci`
   - npm i -g npm@6
   - export DISPLAY=:99.0
+  # Mitigate "Failed: (HTTP code 404) no such container - No such image: dashpay/insight:latest"
+  - docker pull dashpay/insight:latest
 
 install:
   - npm ci

--- a/public/src/js/controllers/transactions.js
+++ b/public/src/js/controllers/transactions.js
@@ -193,7 +193,8 @@ angular.module('insight.transactions').controller('SendRawTransactionController'
     };
     $scope.status = 'loading';
     $http.post(window.apiPrefix + '/tx/send', postData)
-      .success(function(data, status, headers, config) {
+      .then(function(response) {
+        const { data, status, headers, config } = response;
         if(typeof(data.txid) != 'string') {
           // API returned 200 but the format is not known
           $scope.status = 'error';
@@ -204,7 +205,8 @@ angular.module('insight.transactions').controller('SendRawTransactionController'
         $scope.status = 'sent';
         $scope.txid = data.txid;
       })
-      .error(function(data, status, headers, config) {
+      .catch(function(response) {
+        const { data, status, headers, config } = response;
         $scope.status = 'error';
         if(data) {
           $scope.error = data;


### PR DESCRIPTION
As one can see it here : https://code.angularjs.org/snapshot/docs/guide/migration#migrate1.5to1.6-ng-services-$http

In Angular, .success and .error were replaced by .then and .catch. 

Insight-ui seems to already have benefited from such a migration but one part was missing : broadsting transaction such as reported in #57 (thanks to cloudwheels for noticing). 

This PR address that bug and resolves #57. 