### PR TITLE
chore: bump to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/insight-ui",
-  "version": "2.0.12",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/insight-ui",
   "description": "An open-source frontend for the Insight API. The Insight API provides you with a convenient, powerful and simple way to query and broadcast data on the Dash network and build your own services with it.",
-  "version": "2.0.12",
+  "version": "3.0.0",
   "repository": "git://github.com/dashevo/insight-ui.git",
   "contributors": [
     {


### PR DESCRIPTION
This PR brings modifications in order to provide support on the getInfo method which is provided via the `/status` endpoint on insight-api.
Merging this PR will regenerate and redeploy our live service. 

## Notes : 

For proper docker handling, we should merge https://github.com/dashevo/dashcore-node/pull/66 first and https://github.com/dashevo/insight-api/pull/67 afterwards