### PR TITLE
Added Best ChainLock in status page

### DIFF
--- a/public/views/status.html
+++ b/public/views/status.html
@@ -23,7 +23,7 @@
           </tr>
           <tr>
             <td translate>Current Sync Status</td>
-            <td class="text-right"> 
+            <td class="text-right">
             <span  data-ng-show="!sync.error">{{sync.status}}</span>
             <span class="text-danger" data-ng-show="sync.error">
               <span  class="glyphicon glyphicon-warning-sign"></span>
@@ -69,6 +69,27 @@
           <tr>
             <td translate>Current Blockchain Tip (insight)</td>
             <td class="text-right ellipsis"><a href="block/{{syncTipHash}}">{{syncTipHash}}</a></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 translate>Best ChainLock</h2>
+      <table class="table" style="table-layout: fixed" data-ng-controller="StatusController" data-ng-init="getStatus('BestChainLock')">
+        <thead data-ng-include src="'views/includes/infoStatus.html'"></thead>
+        <tbody data-ng-if="!error">
+          <tr>
+            <td translate>ChainLock block hash</td>
+            <td class="text-right ellipsis">
+              <a data-ng-if="bestchainlock.known_block" href="block/{{bestchainlock.blockhash}}">{{bestchainlock.blockhash}}</a>
+              <span data-ng-if="!bestchainlock.known_block" title="This block isn't known by this node yet">{{bestchainlock.blockhash}}</span>
+            </td>
+          </tr>
+          <tr>
+            <td translate>ChainLock block height</td>
+            <td class="text-right ellipsis">
+              <a data-ng-if="bestchainlock.known_block" href="block-index/{{bestchainlock.height}}">{{bestchainlock.height}}</a>
+              <span data-ng-if="!bestchainlock.known_block" title="This block isn't known by this node yet">{{bestchainlock.blockhash}}</span>
+            </td>
           </tr>
         </tbody>
       </table>
@@ -121,4 +142,3 @@
     </div> <!-- END OF COL-GRAY -->
   </div>
 </section>
-


### PR DESCRIPTION
This PR adds a `Best ChainLock` table in the status page, containing information about the block hash and height of the best ChainLock as reported by the node.
This requires https://github.com/dashevo/insight-api/pull/75 to work.

No breaking changes introduced.