### PR TITLE
test(e2e): update backend endpoint

### DIFF
--- a/test/e2e/test.js
+++ b/test/e2e/test.js
@@ -29,7 +29,7 @@ describe('basic UI tests', () => {
           height: 720,
         }))
       .build();
-    url = 'http://insight.testnet.networks.dash.org:3001/insight/';
+    url = 'https://insight.testnet.networks.dash.org/insight/';
   });
 
   describe('Home Page', () => {


### PR DESCRIPTION
# Issue
E2E tests failing with timeout error:

![image](https://github.com/user-attachments/assets/56798b32-2a48-4d11-ac82-3e59acf274f5)

Because testnet endpoint url was changed from `http://insight.testnet.networks.dash.org:3001/insight/` to `https://insight.testnet.networks.dash.org/insight/`
# Things done
* Update E2E tests backend endpoint